### PR TITLE
Fix 'browser_style' warning in manifest.json

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -19,6 +19,7 @@
     ],
 
     "browser_action": {
+	"browser_style": true,
 	"default_icon": {
 	    "16": "icons/password-16.png",
 	    "32": "icons/password-32.png",


### PR DESCRIPTION
You might already be aware of it, but the below warning seen in browser console (at least in Firefox) can be easily fixed:
`WARN Please specify whether you want browser_style or not in your browser_action options.`

Regards