### PR TITLE
Trigger update events when inserting password

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -181,7 +181,8 @@ function performAction(action) {
     case constants.INSERT_PREVIOUS_PASSWORD_MENU:
 	browser.tabs
 	    .executeScript({
-		code: "document.activeElement.value = " + JSON.stringify(password)
+		code: "document.activeElement.value = " + JSON.stringify(password) + 
+		"; ['keyup','keypress','keydown','paste','change'].forEach((event) => document.activeElement.dispatchEvent(new Event(event)))"
 	    })
 	    .catch((error) => {
 		console.error("Failed to set password: ", error);


### PR DESCRIPTION
When inserting or creating a password also dispatch relevant DOM events in the hopes of triggering event listeners that update the page.

This will work on sites where there is an event listener for keyboard events in the password field.
This won't work on sites where [event.isTrusted](https://developer.mozilla.org/en-US/docs/Web/API/Event/isTrusted) is checked (this is checked in some frameworks).
This change could also trigger an error on some sites where an event listener uses event information that this script doesn't add, however as this error is within an event listener it shouldn't affect the sites main thread and the site will continue to function probably.

This should fix #29 